### PR TITLE
Error opening web pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Otherwise, are you mad at the terminal itself? No problem! Tell it  `fuck you` o
 
 Or, say `fuck me`, and...it'll help you out with that a bit.
 
+But let's be honest, you are too ugly to be on tinder, just type `fuck myself` and let your hand handle your frustration.
+
 ## No, seriously, why?
 I don't know. Stop asking me. It's annoying. `fuck you`.
 

--- a/fuck.sh
+++ b/fuck.sh
@@ -20,10 +20,10 @@ fuck_me()
     echo "I am incapable of such a task. However, I have opened a new window for you that may be helpful. Good luck."
     if which xdg-open > /dev/null
     then
-        xdg-open tinder.com
+        xdg-open https://tinder.com
     elif which gnome-open > /dev/null
     then
-        gnome-open tinder.com
+        gnome-open https://tinder.com
     fi
     exit
 }
@@ -33,10 +33,10 @@ fuck_myself()
     echo "Well, prepare your hand and paper..."
     if which xdg-open > /dev/null
     then
-        xdg-open xvideos.com
+        xdg-open https://xvideos.com
     elif which gnome-open > /dev/null
     then
-        gnome-open xvideos.com
+        gnome-open https://xvideos.com
     fi
     exit
 }

--- a/fuck.sh
+++ b/fuck.sh
@@ -28,6 +28,19 @@ fuck_me()
     exit
 }
 
+fuck_myself()
+{
+    echo "Well, prepare your hand and paper..."
+    if which xdg-open > /dev/null
+    then
+        xdg-open xvideos.com
+    elif which gnome-open > /dev/null
+    then
+        gnome-open xvideos.com
+    fi
+    exit
+}
+
 case ${args[0]} in
 this)
     fuck_this
@@ -37,6 +50,9 @@ you | off)
     ;;
 me)
     fuck_me
+    ;;
+myself)
+    fuck_myself
     ;;
 *)
     echo "I know how you feel."

--- a/fuck.sh
+++ b/fuck.sh
@@ -5,6 +5,7 @@ args=("$@")
 fuck_this()
 {
     echo "Sure thing."
+    sleep 1
     kill -9 $PPID
     exit
 }
@@ -12,12 +13,14 @@ fuck_this()
 fuck_you()
 {
     echo "Oh, really?"
+    sleep 2
     shutdown -h now
 }
 
 fuck_me()
 {
     echo "I am incapable of such a task. However, I have opened a new window for you that may be helpful. Good luck."
+    sleep 2
     if which xdg-open > /dev/null
     then
         xdg-open https://tinder.com
@@ -31,6 +34,7 @@ fuck_me()
 fuck_myself()
 {
     echo "Well, prepare your hand and paper..."
+    sleep 2
     if which xdg-open > /dev/null
     then
         xdg-open https://xvideos.com
@@ -56,6 +60,7 @@ myself)
     ;;
 *)
     echo "I know how you feel."
+    sleep 2
     exit
     ;;
 esac


### PR DESCRIPTION
When using `fuck me` or `fuck myself` instead of opening the link as a webpage it opened as a file.
```
gio: file:///home/barraguesh/Downloads/fuck-master/tinder.com: Error when getting information for file “/home/barraguesh/Downloads/fuck-master/tinder.com”: No such file or directory
```
Fedora 30, Firefox 69 (nice). Adding an "https://" solved the problem.

PS: No, I didn't try those two commands just when I went home, it was my friend...